### PR TITLE
Remove Perl Script for Fetching Microsoft Root Store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 - python rootfetch/ct.py > ct.pem
 - python rootfetch/java.py > java.pem
 - python rootfetch/mozilla.py > mozilla.pem
+- python rootfetch/microsoft.py > microsoft.pem
 notifications:
   slack:
     secure: fI+8Y8Xts1Rq8OOdLUGlb3ckgYGflJrvAUxWSTChCKNek9P3Qs0s24tEBuEKTbPqclAcwOiTbRpkC/wKC51pz76DMpeUtA9k4WgiRUrIsNY+fkBCVSEo37/Aq1xdWEqUhBrlYwhxvBx6A/A2xWwNxG2CBnu3kuRpqQ9vHWqE/hYmyt/DSbzzVrvOYZoMX2T+4vIeSP+FhkXj39Tc1S+HOQtQC365kI8EmvV4tZO4O9hM86xMk9K2HB7KRSfNceg+h17N/jNHyGeXaOYIYQzllKItNzg4iEj8DSmoxbccEZCiBtwbHQWdX4Emprpi7M+t69KbOdDVuCuq4YsKHDBS0przrS5NVoFZVTRAj7S0KOzoL3xZrSbEDctOyUrX/wQyfbUg049StLXZeiZW/AC6VGZSqCg1H+qdthUkKdruccJiyUcuvoSb2Whz1d6gGe+g95d/OeWxCb+16HO2piBplQbGjxq6OGQPWiSXVB9fVGeBQ5s49fPwPUefL4GDVAu5p261u2TTYlPn+AjUZ1dU4T5Gz/ZfSJUlDYe6nVl9mJVA9ivRQNTJfNfDzCqRvtTAWj4vHI6Coxiaeadp2Gsk/+PeflWV1XcKsncallH4kkH2z3ulytPMyp2blE2XV+QMJXQbggf5GgR7z23qP4EapFCpNu51Qz7hIooVVAMXYAU=

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Root Fetch
 
 [![Build Status](https://travis-ci.org/zmap/rootfetch.svg?branch=master)](https://travis-ci.org/zmap/rootfetch)
 
-Root Fetch is a set of python scripts for programmatically retrieving the 
+Root Fetch is a set of python scripts for programmatically retrieving the
 root stores from common products. We currently support:
 
   - Apple
@@ -15,13 +15,12 @@ root stores from common products. We currently support:
 Requirements
 ------------
 
-rootfetch is primarily just a wrapper around other tools, but with a common 
+rootfetch is primarily just a wrapper around other tools, but with a common
 interface. As such, it has an eclectic set of requirements.
 
 Microsoft:
 
  - Install cabextract (e.g., `sudo apt-get install cabextract`)
- - Install perl and following CPAN modules: Convert::ASN1, JSON, DateTime (e.g., `sudo cpan Convert::ASN1`)
 
 Mozilla:
 
@@ -30,4 +29,3 @@ Mozilla:
 Apple:
 
  - Install Beautiful Soup (`sudo python setup.py develop`)
-

--- a/rootfetch/microsoft.py
+++ b/rootfetch/microsoft.py
@@ -5,15 +5,44 @@ import subprocess
 import sys
 import urllib
 import urllib2
+import binascii
+from pyasn1.type import univ, namedtype, useful
+from pyasn1.codec.ber import decoder
 
 from rootfetch.base import RootStoreFetcher, RootStoreFetchException
 
+# ASN1 type for the metadata of a single entry in a Microsoft Certificate List
+class CertMetaData(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('MetaDataType', univ.ObjectIdentifier()),
+        namedtype.NamedType('MetaDataValue', univ.Set(
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('RealContent', univ.OctetString())
+        )))
+    )
+
+# ASN1 type for a single entry in a Microsoft Certificate List
+class CTLEntry(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('CertID', univ.OctetString()),
+        namedtype.NamedType('MetaData', univ.SetOf(CertMetaData())),
+        )
+
+# ASN1 type for Microsoft Certificate List
+class CTL(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('dummy1', univ.Any()),
+        namedtype.NamedType('UnknownInt', univ.Integer()),
+        namedtype.NamedType('GenDate', useful.UTCTime()),
+        namedtype.NamedType('dummy4', univ.Any()),
+        namedtype.NamedType('InnerCTL', univ.SequenceOf(CTLEntry())),
+        )
 
 class MicrosoftFetcher(RootStoreFetcher):
     """MicrosoftFetcher fetches the latest root store from Windows Update"""
 
-    PARSECTL_URL = "https://raw.githubusercontent.com/eabalea/MicrosoftRootProgram/master/parsectl.pl"
     CAB_URL = "http://www.download.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab"
+    CERT_DIST_POINT = "http://www.download.windowsupdate.com/msdownload/update/v3/static/trustedr/en/"
 
     def __init__(self):
         super(MicrosoftFetcher, self).__init__()
@@ -26,15 +55,22 @@ class MicrosoftFetcher(RootStoreFetcher):
 
     def setup(self):
         try:
-            subprocess.check_call("perl --version > /dev/null", shell=True)
-        except subprocess.CalledProcessError as e:
-            raise RootStoreFetchException("perl not installed")
-        try:
             subprocess.check_call(
                 "cabextract --version > /dev/null", shell=True)
         except subprocess.CalledProcessError as e:
             raise RootStoreFetchException("cabextract not installed")
-        self._parse_ctl_path, _ = urllib.urlretrieve(self.PARSECTL_URL)
+        self._parse_ctl_path = 'parsectl.pl'
+
+    def parse_ctl(self, ctlpath):
+        dist_points = []
+        with open(ctlpath, "rb") as ctl_file:
+            ctl = ctl_file.read()
+            decoded_ctl = decoder.decode(ctl, asn1Spec=CTL())[0]
+            for entry in decoded_ctl['InnerCTL']:
+                cert_id = binascii.hexlify(entry['CertID'].asOctets())
+                dist_point = self.CERT_DIST_POINT + cert_id + ".crt"
+                dist_points.append(dist_point)
+        return dist_points
 
     def fetch(self, output):
         cab_path, _ = urllib.urlretrieve(self.CAB_URL)
@@ -47,21 +83,15 @@ class MicrosoftFetcher(RootStoreFetcher):
         cmd = "openssl asn1parse -inform D -in {!s} -strparse 63 -out {!s} > /dev/null 2>&1".format(
             extract_path, asn_path)
         subprocess.check_call(cmd, shell=True)
-        res = subprocess.check_output("perl %s %s" % (self._parse_ctl_path,
-                                                      asn_path), shell=True)
-        res = unicode(res.strip(), encoding="utf-8", errors="replace")
-        for cert in json.loads(res)["InnerCTL"]:
-            url = cert["URLToCert"]
-            output.write("# ")
-            output.write(json.dumps(cert))
-            output.write("\n")
+        dist_points = self.parse_ctl(asn_path)
+        for url in dist_points:
             pem = urllib2.urlopen(url).read().encode("base64").strip().replace(
                 "\t", "").replace(" ", "").replace("\n", "")
             output.write("-----BEGIN CERTIFICATE-----\n")
             for l in self.split(pem, 64):
                 output.write(l)
                 output.write("\n")
-            output.write("-----END CERTIFICATE-----\n\n")
+            output.write("-----END CERTIFICATE-----\n")
             output.flush()
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "beautifulsoup4",
         "semver>=2.7,<3",
         "sh>=1.12,<2",
+        "pyasn1>=0.4.4"
     ],
 
     packages = [


### PR DESCRIPTION
The Perl script required to update the Microsoft root store has been replaced with
an implementation in pure Python. The external package `cabextract` is still required
to unpack the compressed list of root certificate distribution points.

fixes #3 