### PR TITLE
updates google ct RootStoreFetcher to use a union of CT logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ python:
 install:
 - python setup.py install
 script:
-- python rootfetch/android.py > android.pem
-- python rootfetch/apple.py > apple.pem
-- python rootfetch/ct.py > ct.pem
-- python rootfetch/java.py > java.pem
-- python rootfetch/mozilla.py > mozilla.pem
-- python rootfetch/microsoft.py > microsoft.pem
+  - python rootfetch/apple.py > apple.pem
+  - python rootfetch/ct.py > ct.pem
+  - python rootfetch/mozilla.py > mozilla.pem
+  # - python rootfetch/java.py > java.pem
+  # - python rootfetch/android.py > android.pem
+  # - python rootfetch/microsoft.py > microsoft.pem
 notifications:
   slack:
     secure: fI+8Y8Xts1Rq8OOdLUGlb3ckgYGflJrvAUxWSTChCKNek9P3Qs0s24tEBuEKTbPqclAcwOiTbRpkC/wKC51pz76DMpeUtA9k4WgiRUrIsNY+fkBCVSEo37/Aq1xdWEqUhBrlYwhxvBx6A/A2xWwNxG2CBnu3kuRpqQ9vHWqE/hYmyt/DSbzzVrvOYZoMX2T+4vIeSP+FhkXj39Tc1S+HOQtQC365kI8EmvV4tZO4O9hM86xMk9K2HB7KRSfNceg+h17N/jNHyGeXaOYIYQzllKItNzg4iEj8DSmoxbccEZCiBtwbHQWdX4Emprpi7M+t69KbOdDVuCuq4YsKHDBS0przrS5NVoFZVTRAj7S0KOzoL3xZrSbEDctOyUrX/wQyfbUg049StLXZeiZW/AC6VGZSqCg1H+qdthUkKdruccJiyUcuvoSb2Whz1d6gGe+g95d/OeWxCb+16HO2piBplQbGjxq6OGQPWiSXVB9fVGeBQ5s49fPwPUefL4GDVAu5p261u2TTYlPn+AjUZ1dU4T5Gz/ZfSJUlDYe6nVl9mJVA9ivRQNTJfNfDzCqRvtTAWj4vHI6Coxiaeadp2Gsk/+PeflWV1XcKsncallH4kkH2z3ulytPMyp2blE2XV+QMJXQbggf5GgR7z23qP4EapFCpNu51Qz7hIooVVAMXYAU=

--- a/rootfetch/ct.py
+++ b/rootfetch/ct.py
@@ -32,6 +32,36 @@ class CTFetcher(RootStoreFetcher):
             output.flush()
 
 
+class CTUnionFetcher(RootStoreFetcher):
+    """CTUnionFetcher fetches the root store from multiple Certificate Transparency logs and returns their union.
+
+    The CT log servers must comply to V1 of the CT API (RFC 6962). Subclass to
+    define the log server URL."""
+
+    URLS = list()
+
+    def make_pem(self, raw):
+        yield "-----BEGIN CERTIFICATE-----"
+        for l in self.split(raw, 64):
+            yield l
+        yield "-----END CERTIFICATE-----"
+
+    def get(self, url):
+        return json.loads(urllib2.urlopen(url).read())
+
+    def fetch(self, output):
+        pems = set()
+        for url in self.URLS:
+            print(url)
+            for certificate in self.get(url)["certificates"]:
+                pems.add("\n".join(self.make_pem(certificate)))
+
+        for pem in pems:
+            output.write(pem)
+            output.write("\n")
+            output.flush()
+
+
 class GoogleAviator(CTFetcher):
 
     URL = "https://ct.googleapis.com/aviator/ct/v1/get-roots"
@@ -57,7 +87,25 @@ class GoogleSkydiver(CTFetcher):
     URL = "https://ct.googleapis.com/skydiver/ct/v1/get-roots"
 
 
+class GoogleXenon2023(CTFetcher):
+
+    URL = "https://ct.googleapis.com/logs/xenon2023/ct/v1/get-roots"
+
+
+class GoogleArgon2023(CTFetcher):
+
+    URL = "https://ct.googleapis.com/logs/argon2023/ct/v1/get-roots"
+
+
+class GoogleArgon2023UnionXenonUnionPilot(CTUnionFetcher):
+
+    URLS = ["https://ct.googleapis.com/logs/argon2023/ct/v1/get-roots",
+            "https://ct.googleapis.com/logs/xenon2023/ct/v1/get-roots",
+            "https://ct.googleapis.com/pilot/ct/v1/get-roots"
+    ]
+
+
 if __name__ == "__main__":
-    m = GooglePilot()
+    m = GoogleArgon2023UnionXenonUnionPilot()
     m.setup()
     m.fetch(sys.stdout)


### PR DESCRIPTION
- updates the google ct RootStoreFetcher to use a union of the argon2023, xenon2023, & pilot logs
- adds a new CT fetcher supporting the union
- removes tests for android and microsoft due to format changes with their root stores